### PR TITLE
Resolve background image not showing after build

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,7 @@
 
 body {
   background-color: rgba(0, 0, 0, 0.85);
-  background-image: url(backdrop_001.png);
+  background-image: url(/backdrop_001.png);
   background-repeat: no-repeat;
   background-size: cover;
   display: flex;


### PR DESCRIPTION
As the title suggests when you build the app and it deploys it to render the background image is missing.

This PR fixes the issue by changing the body css rule

from

background: url(background_001,png)

to

background: url(/background_001,png)